### PR TITLE
Update Discord Activity "name" field as well as the "details" field

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,6 +67,7 @@ class Plugin:
                 "pid": os.getpid(),
                 "activity": {
                     "state": "on Steam Deck",
+                    "name": activity["details"]["name"],
                     "details": "Playing {}".format(activity["details"]["name"]),
                     "assets": {
                         "large_image": activity["imageUrl"],


### PR DESCRIPTION
The Discord Activity object has a "name" field which is intended to be the name of the application currently being played (not "Steam Deck"). I have a listener app that logs what a player is playing from their Discord status--this field should be filled out to allow it to properly know the name of the app/game being played.

https://discord.com/developers/docs/game-sdk/activities#data-models-activity-struct