### PR TITLE
Reference the hardware make and model from DMI data.

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,9 +19,13 @@ with open('/sys/class/dmi/id/sys_vendor', 'r') as file:
     sys_vendor = file.read().replace('\n', '')
     file.close()
 
-with open('/sys/class/dmi/id/product_version', 'r') as file:
-    product_version = file.read().replace('\n', '')
+with open('/sys/class/dmi/id/product_name', 'r') as file:
+    product_name = file.read().replace('\n', '')
     file.close()
+
+if sys_vendor == "Valve":
+    sys_vendor = "Steam"
+    product_name = "Deck"
 
 class EmptyReceiveException(Exception):
     """Raised when the socket was expected data but did not receive any"""
@@ -140,7 +144,7 @@ class Plugin:
                 "args": {
                     "pid": os.getpid(),
                     "activity": {
-                        "state": "on " + sys_vendor + " " + product_version,
+                        "state": "on " + sys_vendor + " " + product_name,
                         "assets": {
                             "large_image": activity["imageUrl"],
                             "small_image": "https://cdn.discordapp.com/app-assets/1055680235682672682/1056080943783354388.png"

--- a/main.py
+++ b/main.py
@@ -15,6 +15,14 @@ OP_CLOSE = 2
 OP_PING = 3
 OP_PONG = 4
 
+with open('/sys/class/dmi/id/sys_vendor', 'r') as file:
+    sys_vendor = file.read().replace('\n', '')
+    file.close()
+
+with open('/sys/class/dmi/id/product_version', 'r') as file:
+    product_version = file.read().replace('\n', '')
+    file.close()
+
 class EmptyReceiveException(Exception):
     """Raised when the socket was expected data but did not receive any"""
 
@@ -132,7 +140,7 @@ class Plugin:
                 "args": {
                     "pid": os.getpid(),
                     "activity": {
-                        "state": "on Steam Deck",
+                        "state": "on " + sys_vendor + " " + product_version,
                         "assets": {
                             "large_image": activity["imageUrl"],
                             "small_image": "https://cdn.discordapp.com/app-assets/1055680235682672682/1056080943783354388.png"


### PR DESCRIPTION
Hi!  I work over at [SteamFork](https://github.com/SteamFork). I installed your Discord status plugin today through Decky and noticed that it sends the device status as "Steam Deck" rather than using the real device data which in my case is an Ayaneo Flip KB.  I thought I'd submit a fix for that, incase you find it interesting.

<img width="279" alt="Screenshot 2025-01-04 at 10 57 52 AM" src="https://github.com/user-attachments/assets/d782448c-8bec-4777-9b2d-d9c7703bdcd6" />

Thanks for considering it!